### PR TITLE
pgweb-dockerのイメージサイズを小さくしたい

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN apk add unzip && unzip pgweb_linux_amd64.zip && mv pgweb_linux_amd64.zip pgw
 FROM alpine:latest
 COPY --from=build ./pgweb ./app
 EXPOSE 8080
-CMD [ "./app/pgweb_linux_amd64", "--sessions" ,"--bind=0.0.0.0", "--listen=8080" ]
+CMD [ "./app/pgweb", "--sessions" ,"--bind=0.0.0.0", "--listen=8080" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:latest as build
 ADD https://github.com/sosedoff/pgweb/releases/download/v0.9.12/pgweb_linux_amd64.zip  ./
-RUN apk add unzip && unzip pgweb_linux_amd64.zip
+RUN apk add unzip && unzip pgweb_linux_amd64.zip && mv pgweb_linux_amd64.zip pgweb
 
 FROM alpine:latest
-COPY --from=build ./ ./app
+COPY --from=build ./pgweb ./app
 EXPOSE 8080
 CMD [ "./app/pgweb_linux_amd64", "--sessions" ,"--bind=0.0.0.0", "--listen=8080" ]


### PR DESCRIPTION
## WHY
https://hub.docker.com/r/sasenomura/pgweb/tags/
のイメージサイズが16MBあることがわかったから
pgweb-dockerのイメージサイズを小さくしたい

## WHAT
docker fileの見直しをして不必要なファイルをimageに含めないようにする